### PR TITLE
Add Mysql support to pulsar manager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,7 @@ dependencies {
     compile group: 'com.github.pagehelper', name: 'pagehelper', version: pagehelperVersion
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-thymeleaf', version: springBootVersion
     compile group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
+    compile group: 'mysql', name: 'mysql-connector-java', version: mysqlVersion
     compile (group: 'org.herddb', name: 'herddb-jdbc', version: herddbVersion) {
         exclude group: 'org.slf4j', module: 'slf4j-jdk14'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@ apiMockitoVersion=1.7.1
 mockitoJunit4Version=1.7.1
 gsonVersion=2.8.2
 postgresqlVersion=42.2.5
+mysqlVersion=5.1.44
 herddbVersion=0.19.0
 brokerVersion=2.4.1
 commonsValidatorVersion=1.6


### PR DESCRIPTION
Fixes #Unable to find mysql jdbc driver dependency

Master Issue: #Missing mysql jdbc connector dependency

### Motivation
When i tried using mysql custom database for pulsar manager i found a bug (unable to find jdbc driver). I fixed it in my local and tested so trying to add the same dependency to apache/pulsar-manager

## Modifications
I changed build.gradle and added mysql dependency
I changed gradle.properties to add version to it

## Verifying this change
I tested in my local and it worked. I am able to connect to my local sql server and use it in pulsar manager running locally through cloned code.

